### PR TITLE
Update MKS_TinyBee_1_XYZAB.yaml

### DIFF
--- a/official/MKS_TinyBee_1_XYZAB.yaml
+++ b/official/MKS_TinyBee_1_XYZAB.yaml
@@ -189,7 +189,7 @@ Laser:
   pwm_hz: 5000
   # EXP1 BTN_ENC
   output_pin: gpio.13
-  # FAN1
+  # HBED
   enable_pin: I2SO.16
   disable_with_s0: false
   s0_with_disable: false


### PR DESCRIPTION
There is a mistake in the annotation that may cause misunderstanding. According to the fact and another annotation below, it should be `HBED`.